### PR TITLE
handle gem os deps given in form of repo

### DIFF
--- a/lib/apaka/packaging/autoproj2adaptor.rb
+++ b/lib/apaka/packaging/autoproj2adaptor.rb
@@ -545,15 +545,22 @@ module Apaka
                     # Convert native ruby gems package names to rock-xxx
                     if pkg_handler == "gem"
                         pkg_list.each do |name|
-                            version = nil
-                            if name =~ /([<>=]=?.*)$/
-                                version = $1
+                            if name.class == Hash
+                                git = name['git']
+                                name = name['name']
+                                version = nil
+                            else
+                                git = nil
+                                version = nil
+                                if name =~ /([<>=]=?.*)$/
+                                    version = $1
+                                end
+
+                                name = name.gsub(/[<>=]=?.*$/,"")
                             end
 
-                            name = name.gsub(/[<>=]=?.*$/,"")
-
-                            extra_gems << [name, version]
-                            non_native_dependencies << [name, version]
+                            extra_gems << [name, version, git]
+                            non_native_dependencies << [name, version, git]
                         end
                     else
                         raise ArgumentError, "cannot package #{pkg.name} as it has non-native dependencies (#{pkg_list}) -- #{pkg_handler.class} #{pkg_handler}"


### PR DESCRIPTION
@2maz, it comes to error if the gem is defined as git repo, e.g. in case of qtbindings

```
qtruby:
    ubuntu:
        "16.04,18.04":
            gem: qtbindings
        default:
            gem:
            - name: qtbindings
              git: https://github.com/rock-core/qtbindings
        osdep: [qt4, qt4-opengl, qt-designer, qt4-webkit, ruby-dev, cmake]
    gentoo:
        kde-base/kdebindings-ruby
```